### PR TITLE
feat: Add ALWAYS_DISPATCH_JOBS_ON_POLL processing option

### DIFF
--- a/config/config.exs
+++ b/config/config.exs
@@ -18,5 +18,4 @@ if Mix.env() == :test do
   config :ecto_job, ecto_repos: [EctoJob.Test.Repo]
 
   config :logger, level: :warn
-
 end

--- a/lib/ecto_job/config.ex
+++ b/lib/ecto_job/config.ex
@@ -24,6 +24,7 @@ defmodule EctoJob.Config do
     - `poll_interval`: (Default `60_000`) Time in milliseconds between polling the `JobQueue` for scheduled jobs or jobs due to be retried
     - `reservation_timeout`: (Default `60_000`) Time in ms during which a `RESERVED` job state is held while waiting for a worker to start the job. Subsequent polls will return the job to the `AVAILABLE` state for retry.
     - `execution_timeout`: (Default `300_000`) Time in ms that a worker is allotted to hold a job in the `IN_PROGRESS` state before subsequent polls return a job to the `AVAILABLE` state for retry. The timeout is extended by `execution_timeout` for every retry attempt until `max_attemps` is reached for a given job.
+    - `always_dispatch_jobs_on_poll`: (Default `false`)
   """
 
   alias __MODULE__
@@ -35,7 +36,8 @@ defmodule EctoJob.Config do
             log_level: :info,
             poll_interval: 60_000,
             reservation_timeout: 60_000,
-            execution_timeout: 300_000
+            execution_timeout: 300_000,
+            always_dispatch_jobs_on_poll: false
 
   @type t :: %Config{}
 
@@ -52,7 +54,8 @@ defmodule EctoJob.Config do
         log_level: :info,
         poll_interval: 60_000,
         reservation_timeout: 60_000,
-        execution_timeout: 300_000
+        execution_timeout: 300_000,
+        always_dispatch_jobs_on_poll: false
       }
   """
   @spec new(Keyword.t()) :: Config.t()

--- a/lib/ecto_job/producer.ex
+++ b/lib/ecto_job/producer.ex
@@ -20,6 +20,7 @@ defmodule EctoJob.Producer do
   @type schema :: module
   @type notifier :: pid
   @type timeout_ms :: non_neg_integer
+  @type always_dispatch_jobs_on_poll :: atom
 
   defmodule State do
     @moduledoc """
@@ -34,7 +35,8 @@ defmodule EctoJob.Producer do
       :clock,
       :poll_interval,
       :reservation_timeout,
-      :execution_timeout
+      :execution_timeout,
+      :always_dispatch_jobs_on_poll
     ]
 
     defstruct [
@@ -45,7 +47,8 @@ defmodule EctoJob.Producer do
       :clock,
       :poll_interval,
       :reservation_timeout,
-      :execution_timeout
+      :execution_timeout,
+      :always_dispatch_jobs_on_poll
     ]
 
     @type t :: %__MODULE__{
@@ -56,7 +59,8 @@ defmodule EctoJob.Producer do
             clock: (() -> DateTime.t()),
             poll_interval: non_neg_integer(),
             reservation_timeout: EctoJob.Producer.timeout_ms(),
-            execution_timeout: EctoJob.Producer.timeout_ms()
+            execution_timeout: EctoJob.Producer.timeout_ms(),
+            always_dispatch_jobs_on_poll: EctoJob.Producer.always_dispatch_jobs_on_poll()
           }
   end
 
@@ -68,8 +72,26 @@ defmodule EctoJob.Producer do
    - `notifier` : The name of the `Postgrex.Notifications` notifier process
    - `poll_interval` : Timer interval for activating scheduled/expired jobs
   """
-  @spec start_link(name: atom, repo: repo, schema: schema, notifier: atom, poll_interval: non_neg_integer, reservation_timeout: timeout_ms(), execution_timeout: timeout_ms()) :: {:ok, pid}
-  def start_link(name: name, repo: repo, schema: schema, notifier: notifier, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout) do
+  @spec start_link(
+          name: atom,
+          repo: repo,
+          schema: schema,
+          notifier: atom,
+          poll_interval: non_neg_integer,
+          reservation_timeout: timeout_ms(),
+          execution_timeout: timeout_ms(),
+          always_dispatch_jobs_on_poll: atom
+        ) :: {:ok, pid}
+  def start_link(
+        name: name,
+        repo: repo,
+        schema: schema,
+        notifier: notifier,
+        poll_interval: poll_interval,
+        reservation_timeout: reservation_timeout,
+        execution_timeout: execution_timeout,
+        always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
+      ) do
     GenStage.start_link(
       __MODULE__,
       %State{
@@ -80,7 +102,8 @@ defmodule EctoJob.Producer do
         clock: &DateTime.utc_now/0,
         poll_interval: poll_interval,
         reservation_timeout: reservation_timeout,
-        execution_timeout: execution_timeout
+        execution_timeout: execution_timeout,
+        always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
       },
       name: name
     )
@@ -125,7 +148,9 @@ defmodule EctoJob.Producer do
     now = clock.()
     _ = JobQueue.fail_expired_jobs_at_max_attempts(repo, schema, now)
 
-    if activate_jobs(repo, schema, now) > 0 do
+    activated_job_count = activate_jobs(repo, schema, now)
+
+    if state.always_dispatch_jobs_on_poll || activated_job_count > 0 do
       dispatch_jobs(state, now)
     else
       {:noreply, [], state}

--- a/lib/ecto_job/supervisor.ex
+++ b/lib/ecto_job/supervisor.ex
@@ -32,8 +32,18 @@ defmodule EctoJob.Supervisor do
   @doc """
   Starts an EctoJob queue supervisor
   """
-  @spec start_link(Config.t) :: {:ok, pid}
-  def start_link(config = %Config{repo: repo, schema: schema, max_demand: max_demand, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout}) do
+  @spec start_link(Config.t()) :: {:ok, pid}
+  def start_link(
+        config = %Config{
+          repo: repo,
+          schema: schema,
+          max_demand: max_demand,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
+        }
+      ) do
     supervisor_name = String.to_atom("#{schema}.Supervisor")
     notifier_name = String.to_atom("#{schema}.Notifier")
     producer_name = String.to_atom("#{schema}.Producer")
@@ -41,7 +51,16 @@ defmodule EctoJob.Supervisor do
     children = [
       worker(Postgrex.Notifications, [repo.config() ++ [name: notifier_name]]),
       worker(Producer, [
-        [name: producer_name, repo: repo, schema: schema, notifier: notifier_name, poll_interval: poll_interval, reservation_timeout: reservation_timeout, execution_timeout: execution_timeout]
+        [
+          name: producer_name,
+          repo: repo,
+          schema: schema,
+          notifier: notifier_name,
+          poll_interval: poll_interval,
+          reservation_timeout: reservation_timeout,
+          execution_timeout: execution_timeout,
+          always_dispatch_jobs_on_poll: always_dispatch_jobs_on_poll
+        ]
       ]),
       supervisor(WorkerSupervisor, [
         [config: config, subscribe_to: [{producer_name, max_demand: max_demand}]]

--- a/test/producer_test.exs
+++ b/test/producer_test.exs
@@ -16,6 +16,7 @@ defmodule EctoJob.ProducerTest do
         poll_interval: 60_000,
         reservation_timeout: 60_000,
         execution_timeout: 300_000,
+        always_dispatch_jobs_on_poll: false
       }
     }
   end
@@ -32,6 +33,28 @@ defmodule EctoJob.ProducerTest do
 
       assert {:noreply, [%JobQueue{}], %{demand: 9}} =
                Producer.handle_info(:poll, %{state | demand: 10})
+    end
+
+    test "When always_dispatch_jobs_on_poll is true", %{state: state} do
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [%JobQueue{}], %{demand: 9}} =
+               Producer.handle_info(:poll, %{
+                 state
+                 | demand: 10,
+                   always_dispatch_jobs_on_poll: true
+               })
+    end
+
+    test "When always_dispatch_jobs_on_poll is false", %{state: state} do
+      Repo.insert!(JobQueue.new(%{}))
+
+      assert {:noreply, [], %{demand: 10}} =
+               Producer.handle_info(:poll, %{
+                 state
+                 | demand: 10,
+                   always_dispatch_jobs_on_poll: false
+               })
     end
   end
 


### PR DESCRIPTION
Altera o formato de pooling da biblioteca para pegar todos os jobs disponíveis para processamento.

Essa opção é configurável pela flag ALWAYS_DISPATCH_JOBS_ON_POLL.

O comportamento default é o original, onde são processados no pool apenas agendamentos expirados e agendados (com data já alcançada).